### PR TITLE
Initialize design and basic game framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # Agent Arena
-A bunch of 1v1 games that LLM agents can play against each other to test evaluate the quality of their prompts. 
+
+Agent Arena is a playground for evaluating language model agents through head-to-head games. Each game is turn-based, produces a single winner, and exposes its state as text so that LLMs can decide on their next move.
+
+The project is organized as a small Python package with a common interface for games and players. New games can be added by implementing the `Game` interface.
+
+## Getting Started
+
+1. Install Python 3.10 or later.
+2. Clone the repository and install the package in editable mode:
+
+```bash
+pip install -e .
+```
+
+3. Run an example match:
+
+```python
+from arena.games.tictactoe import TicTacToe
+from arena import GameEngine, RandomPlayer
+
+engine = GameEngine(TicTacToe(), RandomPlayer(), RandomPlayer())
+winner = engine.play()
+print("Winner:", winner)
+```
+
+## Documentation
+
+Detailed design notes live in [docs/DESIGN.md](docs/DESIGN.md).

--- a/arena/__init__.py
+++ b/arena/__init__.py
@@ -1,0 +1,6 @@
+"""Agent Arena core package."""
+
+from .base import Game, Player, RandomPlayer
+from .engine import GameEngine
+
+__all__ = ["Game", "Player", "RandomPlayer", "GameEngine"]

--- a/arena/base.py
+++ b/arena/base.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, List
+
+
+class Game(ABC):
+    """Abstract base class for turn-based two-player games."""
+
+    @abstractmethod
+    def reset(self) -> Any:
+        """Return the initial game state."""
+
+    @abstractmethod
+    def valid_actions(self, state: Any) -> List[str]:
+        """Return a list of valid actions for the given state."""
+
+    @abstractmethod
+    def apply_action(self, state: Any, action: str) -> Any:
+        """Return a new state after applying `action` to `state`."""
+
+    @abstractmethod
+    def is_terminal(self, state: Any) -> bool:
+        """Return True if the game is over."""
+
+    @abstractmethod
+    def get_winner(self, state: Any) -> int | None:
+        """Return 0 or 1 for the winning player, or None if undecided."""
+
+    @abstractmethod
+    def render(self, state: Any) -> str:
+        """Return a text representation of `state` for LLM consumption."""
+
+
+class Player(ABC):
+    """Base class for players."""
+
+    @abstractmethod
+    def select_action(self, game: Game, state: Any) -> str:
+        """Return the action to take given the current state."""
+
+
+class RandomPlayer(Player):
+    """Baseline player that selects a random valid action."""
+
+    def select_action(self, game: Game, state: Any) -> str:
+        import random
+
+        actions = game.valid_actions(state)
+        return random.choice(actions)

--- a/arena/engine.py
+++ b/arena/engine.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .base import Game, Player
+
+
+class GameEngine:
+    """Run a match between two players."""
+
+    def __init__(self, game: Game, player0: Player, player1: Player):
+        self.game = game
+        self.players = [player0, player1]
+
+    def play(self) -> int:
+        """Run the game and return the winning player (0 or 1)."""
+        state = self.game.reset()
+        current = 0
+        while not self.game.is_terminal(state):
+            player = self.players[current]
+            action = player.select_action(self.game, state)
+            state = self.game.apply_action(state, action)
+            current = 1 - current
+        winner = self.game.get_winner(state)
+        assert winner is not None
+        return winner

--- a/arena/games/__init__.py
+++ b/arena/games/__init__.py
@@ -1,0 +1,3 @@
+from .tictactoe import TicTacToe
+
+__all__ = ["TicTacToe"]

--- a/arena/games/tictactoe.py
+++ b/arena/games/tictactoe.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+from ..base import Game
+
+
+class TicTacToe(Game):
+    """Simple 3x3 tic-tac-toe implementation."""
+
+    def reset(self) -> List[str]:
+        return [" "] * 9
+
+    def valid_actions(self, state: List[str]) -> List[str]:
+        return [str(i) for i, cell in enumerate(state) if cell == " "]
+
+    def apply_action(self, state: List[str], action: str) -> List[str]:
+        idx = int(action)
+        if state[idx] != " ":
+            raise ValueError("Invalid move")
+        new_state = state.copy()
+        new_state[idx] = self._current_player(state)
+        return new_state
+
+    def is_terminal(self, state: List[str]) -> bool:
+        return self.get_winner(state) is not None or all(cell != " " for cell in state)
+
+    def get_winner(self, state: List[str]) -> int | None:
+        lines = [
+            (0, 1, 2),
+            (3, 4, 5),
+            (6, 7, 8),
+            (0, 3, 6),
+            (1, 4, 7),
+            (2, 5, 8),
+            (0, 4, 8),
+            (2, 4, 6),
+        ]
+        for a, b, c in lines:
+            if state[a] != " " and state[a] == state[b] == state[c]:
+                return 0 if state[a] == "X" else 1
+        return None
+
+    def render(self, state: List[str]) -> str:
+        rows = ["|".join(state[i : i + 3]) for i in range(0, 9, 3)]
+        board = "\n-----\n".join(rows)
+        return f"```\n{board}\n```"
+
+    def _current_player(self, state: List[str]) -> str:
+        x_count = state.count("X")
+        o_count = state.count("O")
+        return "X" if x_count == o_count else "O"

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,42 @@
+# Agent Arena Design Overview
+
+## Purpose
+Agent Arena is a collection of turn-based, two-player games designed for language model agents. Each game produces a single winner and exposes its state as text so agents can reason about their moves through prompts.
+
+## Core Concepts
+
+- **Game interface**: All games implement a common `Game` interface defined in `arena/base.py`. The interface exposes methods for resetting the game, listing valid actions, applying actions, detecting terminal states, retrieving the winner, and rendering the current state to text.
+- **Game implementations**: Individual games live under `arena/games/`. Each game inherits from `Game` and implements game-specific logic. The initial example is `TicTacToe`.
+- **Players**: Agents control players by choosing actions. A simple `RandomPlayer` is provided as a baseline. LLM-driven players will implement the same interface.
+- **Game manager**: The `arena.engine` module runs a match between two players, handling turn order and enforcing the game rules.
+
+## Design Goals
+
+1. **Ease of adding new games** – Implementing the `Game` interface should be straightforward. Minimal additional infrastructure should be required.
+2. **Text-only interfaces** – To maximize compatibility with LLMs, games communicate exclusively via text.
+3. **Deterministic outcomes** – Each game should have clear win conditions and no hidden information to keep evaluation straightforward.
+4. **Extensibility** – Additional components such as tournaments or rating systems can build on top of the basic game manager.
+
+## Directory Structure
+
+```text
+agent-arena/
+├── arena/            # Python package with core modules
+│   ├── __init__.py
+│   ├── base.py       # Game and Player base classes
+│   ├── engine.py     # Logic to run games between two players
+│   └── games/
+│       ├── __init__.py
+│       └── tictactoe.py
+├── docs/
+│   └── DESIGN.md
+└── README.md
+```
+
+## Future Work
+
+- Implement additional games (e.g., Connect Four, Nim).
+- Add rating systems to track agent performance.
+- Provide a command-line interface to run matches and tournaments.
+- Explore reinforcement learning setups for automated prompt evolution.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "agent-arena"
+version = "0.1.0"
+description = "Turn-based games for LLM agent evaluation"
+requires-python = ">=3.10"
+
+[project.optional-dependencies]
+test = ["pytest"]


### PR DESCRIPTION
## Summary
- expand README with project overview and usage
- outline the architecture in `docs/DESIGN.md`
- add a lightweight Python package with base classes and engine
- implement a simple TicTacToe game example
- provide `pyproject.toml` for package metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400480786483249acbb2976088c9a2