### PR TITLE
Add Connect Four and Nim games

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Agent Arena is a playground for evaluating language model agents through head-to
 
 The project is organized as a small Python package with a common interface for games and players. New games can be added by implementing the `Game` interface.
 
+Current built-in games include TicTacToe, Connect Four, and Nim.
+
 ## Getting Started
 
 1. Install Python 3.10 or later.

--- a/arena/games/__init__.py
+++ b/arena/games/__init__.py
@@ -1,3 +1,5 @@
 from .tictactoe import TicTacToe
+from .connect_four import ConnectFour
+from .nim import Nim
 
-__all__ = ["TicTacToe"]
+__all__ = ["TicTacToe", "ConnectFour", "Nim"]

--- a/arena/games/connect_four.py
+++ b/arena/games/connect_four.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+from ..base import Game
+
+
+class ConnectFour(Game):
+    """Classic Connect Four on a 7x6 board."""
+
+    def __init__(self, rows: int = 6, cols: int = 7, connect: int = 4):
+        self.rows = rows
+        self.cols = cols
+        self.connect = connect
+
+    def reset(self) -> List[List[str]]:
+        return [[" "] * self.cols for _ in range(self.rows)]
+
+    def valid_actions(self, state: List[List[str]]) -> List[str]:
+        return [str(c) for c in range(self.cols) if state[0][c] == " "]
+
+    def apply_action(self, state: List[List[str]], action: str) -> List[List[str]]:
+        col = int(action)
+        if state[0][col] != " ":
+            raise ValueError("Invalid move")
+        piece = self._current_player(state)
+        new_state = [row.copy() for row in state]
+        for r in range(self.rows - 1, -1, -1):
+            if new_state[r][col] == " ":
+                new_state[r][col] = piece
+                break
+        return new_state
+
+    def is_terminal(self, state: List[List[str]]) -> bool:
+        return self.get_winner(state) is not None or all(state[0][c] != " " for c in range(self.cols))
+
+    def get_winner(self, state: List[List[str]]) -> int | None:
+        for r in range(self.rows):
+            for c in range(self.cols):
+                piece = state[r][c]
+                if piece == " ":
+                    continue
+                if self._check_direction(state, r, c, 1, 0, piece):
+                    return 0 if piece == "X" else 1
+                if self._check_direction(state, r, c, 0, 1, piece):
+                    return 0 if piece == "X" else 1
+                if self._check_direction(state, r, c, 1, 1, piece):
+                    return 0 if piece == "X" else 1
+                if self._check_direction(state, r, c, 1, -1, piece):
+                    return 0 if piece == "X" else 1
+        return None
+
+    def render(self, state: List[List[str]]) -> str:
+        rows = ["|".join(row) for row in state]
+        board = "\n".join(rows)
+        return f"```\n{board}\n```"
+
+    def _check_direction(self, state: List[List[str]], r: int, c: int, dr: int, dc: int, piece: str) -> bool:
+        for i in range(1, self.connect):
+            nr, nc = r + dr * i, c + dc * i
+            if nr < 0 or nr >= self.rows or nc < 0 or nc >= self.cols:
+                return False
+            if state[nr][nc] != piece:
+                return False
+        return True
+
+    def _current_player(self, state: List[List[str]]) -> str:
+        flat = sum(state, [])
+        x_count = flat.count("X")
+        o_count = flat.count("O")
+        return "X" if x_count == o_count else "O"

--- a/arena/games/nim.py
+++ b/arena/games/nim.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import List
+
+from ..base import Game
+
+
+class Nim(Game):
+    """Simple impartial game of Nim with a single heap."""
+
+    def __init__(self, total: int = 12, max_take: int = 3):
+        self.total = total
+        self.max_take = max_take
+
+    def reset(self) -> int:
+        return self.total
+
+    def valid_actions(self, state: int) -> List[str]:
+        return [str(i) for i in range(1, min(self.max_take, state) + 1)]
+
+    def apply_action(self, state: int, action: str) -> int:
+        take = int(action)
+        if take < 1 or take > self.max_take or take > state:
+            raise ValueError("Invalid move")
+        return state - take
+
+    def is_terminal(self, state: int) -> bool:
+        return state == 0
+
+    def get_winner(self, state: int) -> int | None:
+        if state != 0:
+            return None
+        moves_made = self.total - state
+        return (moves_made - 1) % 2
+
+    def render(self, state: int) -> str:
+        sticks = "|" * state
+        return f"Remaining: {state}\n```\n{sticks}\n```"

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -35,7 +35,6 @@ agent-arena/
 
 ## Future Work
 
-- Implement additional games (e.g., Connect Four, Nim).
 - Add rating systems to track agent performance.
 - Provide a command-line interface to run matches and tournaments.
 - Explore reinforcement learning setups for automated prompt evolution.

--- a/tests/test_games.py
+++ b/tests/test_games.py
@@ -1,0 +1,19 @@
+from arena.games.connect_four import ConnectFour
+from arena.games.nim import Nim
+
+
+def test_connect_four_vertical_win():
+    game = ConnectFour()
+    state = game.reset()
+    moves = ["0", "1", "0", "1", "0", "1", "0"]
+    for m in moves:
+        state = game.apply_action(state, m)
+    assert game.get_winner(state) == 0
+
+
+def test_nim_simple_win():
+    game = Nim(total=3, max_take=3)
+    state = game.reset()
+    state = game.apply_action(state, "3")
+    assert game.is_terminal(state)
+    assert game.get_winner(state) == 0


### PR DESCRIPTION
## Summary
- add ConnectFour and Nim game implementations
- list the built-in games in README
- update DESIGN docs to remove TODO
- test basic winning scenarios for both games

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684006d646188324ac13853d44f9aa88