### PR TITLE
Add game backlog and contribution guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Agent Arena is a playground for evaluating language model agents through head-to
 The project is organized as a small Python package with a common interface for games and players. New games can be added by implementing the `Game` interface.
 
 Current built-in games include TicTacToe, Connect Four, and Nim.
+Planned games are listed in [docs/GAME_BACKLOG.md](docs/GAME_BACKLOG.md).
+
+If you'd like to contribute a new game, see [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md).
 
 ## Getting Started
 

--- a/arena/games/__init__.py
+++ b/arena/games/__init__.py
@@ -1,5 +1,25 @@
-from .tictactoe import TicTacToe
-from .connect_four import ConnectFour
-from .nim import Nim
+"""Game package auto-discovery.
 
-__all__ = ["TicTacToe", "ConnectFour", "Nim"]
+Rather than manually editing this file every time a new game is added, we
+automatically import any modules in this package that define subclasses of the
+``Game`` base class.  This keeps merge conflicts to a minimum because new games
+only need to add a new module and do not modify shared files.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+
+from ..base import Game
+
+__all__: list[str] = []
+
+for finder, name, ispkg in pkgutil.iter_modules(__path__):
+    module = importlib.import_module(f"{__name__}.{name}")
+    for attr_name, attr in vars(module).items():
+        if inspect.isclass(attr) and issubclass(attr, Game) and attr is not Game:
+            globals()[attr_name] = attr
+            __all__.append(attr_name)
+

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing New Games
+
+To add a new game implementation without stepping on other developers' work, follow these guidelines:
+
+1. **Create a new module** under `arena/games/` with a descriptive file name (e.g. `my_game.py`). Implement a class that subclasses `Game`.
+2. **Do not modify** `arena/games/__init__.py`. Game classes are automatically discovered when the package is imported.
+3. Add a corresponding test module under `tests/` demonstrating the basic win condition for your game.
+4. Update `docs/GAME_BACKLOG.md` to mark the game as implemented if applicable.
+
+Because each game lives in its own file and no central registry needs updating, multiple contributors can work in parallel with minimal merge conflicts.

--- a/docs/GAME_BACKLOG.md
+++ b/docs/GAME_BACKLOG.md
@@ -1,0 +1,25 @@
+# Planned Games
+
+This document lists candidate games for future implementation. The goal is to cover a wide range of reasoning and planning capabilities.
+
+## Board Strategy
+- **Checkers** – classic 8x8 draughts game.
+- **Chess (mini variant)** – simplified board for long-term planning.
+- **Gomoku** – five in a row on a 15x15 board.
+- **Othello** – flipping pieces to control territory.
+- **Hex** – path connection game on a rhombus board.
+- **Dots and Boxes** – claiming edges to complete squares.
+- **Mancala** – resource sowing and capture.
+- **Quoridor** – race to the opposite side while placing walls.
+- **Ultimate TicTacToe** – tic-tac-toe boards inside a larger grid.
+
+## Word and Deduction
+- **Word Ladder Duel** – players alternately change one letter to reach a goal word.
+- **Hangman** – guess the hidden word one letter at a time.
+- **Mastermind** – code-breaking with feedback.
+
+## Mathematical Puzzles
+- **Multi-heap Nim** – generalization of the existing single-heap Nim.
+- **Sudoku Race** – players take turns filling numbers on a shared grid.
+
+These games span pure strategy, deduction, memory, and arithmetic reasoning.


### PR DESCRIPTION
## Summary
- auto-discover games by scanning `arena/games` package
- document upcoming games and how to contribute
- reference docs from README
- add `.gitignore`

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840088fc9c4832492110632a56a0d39