### PR TITLE
Add Word Ladder Duel game

### DIFF
--- a/arena/games/word_ladder_duel.py
+++ b/arena/games/word_ladder_duel.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any, List, Tuple, Iterable
+
+from ..base import Game
+
+
+class WordLadderDuel(Game):
+    """Two-player word ladder race from start to goal."""
+
+    def __init__(self, start: str, goal: str, dictionary: Iterable[str] | None = None):
+        if len(start) != len(goal):
+            raise ValueError("start and goal must be the same length")
+        self.start = start.lower()
+        self.goal = goal.lower()
+        self.dictionary = set(w.lower() for w in dictionary) if dictionary else None
+        self.alphabet = "abcdefghijklmnopqrstuvwxyz"
+
+    def reset(self) -> Tuple[str, int]:
+        return (self.start, 0)
+
+    def valid_actions(self, state: Tuple[str, int]) -> List[str]:
+        word, _ = state
+        actions: List[str] = []
+        for i, ch in enumerate(word):
+            for new_ch in self.alphabet:
+                if new_ch == ch:
+                    continue
+                candidate = word[:i] + new_ch + word[i + 1 :]
+                if self.dictionary is None or candidate in self.dictionary:
+                    actions.append(candidate)
+        return actions
+
+    def apply_action(self, state: Tuple[str, int], action: str) -> Tuple[str, int]:
+        word, count = state
+        action = action.lower()
+        if len(action) != len(word):
+            raise ValueError("Invalid word length")
+        diff = sum(a != b for a, b in zip(word, action))
+        if diff != 1:
+            raise ValueError("Action must change exactly one letter")
+        if self.dictionary is not None and action not in self.dictionary:
+            raise ValueError("Word not in dictionary")
+        return (action, count + 1)
+
+    def is_terminal(self, state: Tuple[str, int]) -> bool:
+        return state[0] == self.goal
+
+    def get_winner(self, state: Tuple[str, int]) -> int | None:
+        word, count = state
+        if word != self.goal:
+            return None
+        return (count - 1) % 2
+
+    def render(self, state: Tuple[str, int]) -> str:
+        word, _ = state
+        return f"Current: {word} -> Goal: {self.goal}"

--- a/docs/GAME_BACKLOG.md
+++ b/docs/GAME_BACKLOG.md
@@ -14,7 +14,7 @@ This document lists candidate games for future implementation. The goal is to co
 - **Ultimate TicTacToe** – tic-tac-toe boards inside a larger grid.
 
 ## Word and Deduction
-- **Word Ladder Duel** – players alternately change one letter to reach a goal word.
+- **Word Ladder Duel** – players alternately change one letter to reach a goal word. (implemented)
 - **Hangman** – guess the hidden word one letter at a time.
 - **Mastermind** – code-breaking with feedback.
 

--- a/tests/test_word_ladder_duel.py
+++ b/tests/test_word_ladder_duel.py
@@ -1,0 +1,12 @@
+from arena.games.word_ladder_duel import WordLadderDuel
+
+
+def test_word_ladder_duel_path():
+    dictionary = ["cold", "cord", "card", "ward", "warm"]
+    game = WordLadderDuel("cold", "warm", dictionary)
+    state = game.reset()
+    moves = ["cord", "card", "ward", "warm"]
+    for move in moves:
+        state = game.apply_action(state, move)
+    assert game.is_terminal(state)
+    assert game.get_winner(state) == 1


### PR DESCRIPTION
## Summary
- implement `WordLadderDuel` game
- test the new game path to victory
- mark Word Ladder Duel as implemented in backlog

## Testing
- `pip install -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684009f77d6c8324a30275611f6277f3